### PR TITLE
Add missing #include for cstdlib

### DIFF
--- a/SimpleIni.h
+++ b/SimpleIni.h
@@ -213,6 +213,7 @@
 #endif
 
 #include <cstring>
+#include <cstdlib>
 #include <string>
 #include <map>
 #include <list>


### PR DESCRIPTION
Required for functions like strtol. It seems that some compilers include cstdlib as part of cstring. But, this code fails to build on clang due to the missing include.