### PR TITLE
Before including windows.h, define NOMINMAX if needed

### DIFF
--- a/SimpleIni.h
+++ b/SimpleIni.h
@@ -3245,7 +3245,13 @@ public:
 # endif
 #endif
 
+#ifdef NOMINMAX
 #include <windows.h>
+#else
+#define NOMINMAX
+#include <windows.h>
+#undef NOMINMAX
+#endif
 #ifdef SI_NO_MBCS
 # define SI_NoCase   SI_GenericNoCase
 #else // !SI_NO_MBCS


### PR DESCRIPTION
Including windows.h pollutes the namespace with macros which tend to conflict with standard functions (such as: std::numeric_limits::max() ). This define helps to reduce it's effect.