### PR TITLE
Fix failure on loading empty file

### DIFF
--- a/SimpleIni.h
+++ b/SimpleIni.h
@@ -1416,16 +1416,16 @@ CSimpleIniTempl<SI_CHAR,SI_STRLESS,SI_CONVERTER>::LoadData(
 {
     SI_CONVERTER converter(m_bStoreIsUtf8);
 
-    if (a_uDataLen == 0) {
-        return SI_OK;
-    }
-
     // consume the UTF-8 BOM if it exists
     if (m_bStoreIsUtf8 && a_uDataLen >= 3) {
         if (memcmp(a_pData, SI_UTF8_SIGNATURE, 3) == 0) {
             a_pData    += 3;
             a_uDataLen -= 3;
         }
+    }
+
+    if (a_uDataLen == 0) {
+        return SI_OK;
     }
 
     // determine the length of the converted data


### PR DESCRIPTION
Re: #19

The Windows, Unicode, UTF-8 version of SizeFromStore returns failure when
given zero-length data. Fix by moving a_uDataLen == 0 check to after the
UTF-8 BOM removal.