### PR TITLE
Added option for allowing keys with no value

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ ini.SetValue("section", "key", "newvalue");
 
 ```c++
 // load from a data file
-CSimpleIniA ini(a_bIsUtf8, a_bUseMultiKey, a_bUseMultiLine);
+CSimpleIniA ini(a_bIsUtf8, a_bUseMultiKey, a_bUseMultiLine, a_bAllowEmptyValues);
 SI_Error rc = ini.LoadFile(a_pszFile);
 if (rc < 0) return false;
 


### PR DESCRIPTION
I found myself in need of being able to read ini files where there are keys without values, i.e.:

```
[section]
key1
key2
...
```

Since I quite like SimpleIni and wanted to keep using it, I made an edit where lines that have a key with no value will be parsed as a key with a value of length 0 rather than skipped. This breaks from the conventional ini format but is useful in some cases, and there may be other people that would find this useful. The user has to opt into it using the SetAllowEmptyValues method or by passing a parameter into the SimpleIni constructor.
