### PR TITLE
Make compile with C++17

### DIFF
--- a/SimpleIni.h
+++ b/SimpleIni.h
@@ -328,7 +328,7 @@ public:
 #endif
 
         /** Strict less ordering by name of key only */
-        struct KeyOrder : std::binary_function<Entry, Entry, bool> {
+        struct KeyOrder {
             bool operator()(const Entry & lhs, const Entry & rhs) const {
                 const static SI_STRLESS isLess = SI_STRLESS();
                 return isLess(lhs.pItem, rhs.pItem);
@@ -336,7 +336,7 @@ public:
         };
 
         /** Strict less ordering by order, and then name of key */
-        struct LoadOrder : std::binary_function<Entry, Entry, bool> {
+        struct LoadOrder {
             bool operator()(const Entry & lhs, const Entry & rhs) const {
                 if (lhs.nOrder != rhs.nOrder) {
                     return lhs.nOrder < rhs.nOrder;


### PR DESCRIPTION
Fix compilation with C++17.

It still compiles with older C++ standards in MSVC15.

binary_function was deprecated in C++11 and removed in C++17 (cf. https://en.cppreference.com/w/cpp/utility/functional/binary_function).