### PR TITLE
Fix tests/Makefile

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,14 +1,15 @@
-CC=g++
-CFLAGS=-Wall -std=c++11
-CPPFLAGS=-Wall -std=c++11
-LDFLAGS=-lpthread -lgtest -lgtest_main -lpthread -L/usr/lib -L/usr/lib/x86_64-linux-gnu
+CXX?=g++
+CXXFLAGS+=-Wall -std=c++11 `pkg-config --cflags gtest_main`
+LDFLAGS+=`pkg-config --libs gtest_main`
 
 OBJS=ts-roundtrip.o ts-snippets.o ts-utf8.o ts-bugfix.o ts-quotes.o ts-noconvert.o
 
 BIN=./tests
 
-all: $(OBJS)
-	$(CC) -o $(BIN) $(OBJS) $(LDFLAGS)
+all: $(BIN)
+
+$(BIN): $(OBJS)
+	$(CXX) -o $(BIN) $(OBJS) $(LDFLAGS)
 
 clean:
 	rm -f core $(OBJS) $(BIN)


### PR DESCRIPTION
- Use CXX/CXXFLAGS as this is c++ code and CFLAGS/CPPFLAGS are unrelated
- Allow flags to be provided by the environment
- Use pkg-config for gtest discovery instead of using nonportable hardcoded flags
- Name target after the file it produces