### PR TITLE
Added basic CMake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,6 @@ endif()
 get_filename_component(srcdir "${CMAKE_SOURCE_DIR}" REALPATH)
 get_filename_component(bindir "${CMAKE_BINARY_DIR}" REALPATH)
 
-# disallow in-source builds
 if("${srcdir}" STREQUAL "${bindir}")
 	message("")
 	message("ERROR:: in-source builds are disabled!")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,21 @@ else()
 	set(IS_TOPLEVEL_PROJECT FALSE)
 endif()
 
+# Disable in-source builds:
+get_filename_component(srcdir "${CMAKE_SOURCE_DIR}" REALPATH)
+get_filename_component(bindir "${CMAKE_BINARY_DIR}" REALPATH)
+
+# disallow in-source builds
+if("${srcdir}" STREQUAL "${bindir}")
+	message("")
+	message("ERROR:: in-source builds are disabled!")
+	message("Run cmake in a separate build directory:")
+	message("$ cmake -S . -B build")
+	message("")
+	message(FATAL_ERROR "Aborting...")
+endif()
+
+# Define library paths and include directories
 set(EXPORT_NAMESPACE "${PROJECT_NAME}::")
 set(HEADERS SimpleIni.h)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.14)
+
+project(
+	SimpleIni
+	VERSION 4.20
+	DESCRIPTION "Cross-platform C++ library providing a simple API to read and write INI-style configuration files"
+	LANGUAGES CXX
+)
+
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+	set(IS_TOPLEVEL_PROJECT TRUE)
+else()
+	set(IS_TOPLEVEL_PROJECT FALSE)
+endif()
+
+set(EXPORT_NAMESPACE "${PROJECT_NAME}::")
+set(HEADERS SimpleIni.h)
+
+add_library(${PROJECT_NAME} INTERFACE)
+add_library(${EXPORT_NAMESPACE}${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+
+target_include_directories(${PROJECT_NAME} INTERFACE .)
+


### PR DESCRIPTION
This will enable package managers and projects that relies on CMake, like [CPM](https://github.com/cpm-cmake/CPM.cmake) to add SimpleIni as a dependency easily.

Two targets are exposed:
* SimpleIni
* SimpleIni::SimpleIni

In your code you can just `include <SimpleIni.h>` after it.

PS: Also bumped the version in `CMakeLists.txt` to 4.20 hoping we get a new release with CMake support.