### PR TITLE
Add casts to prevent integer overflow

### DIFF
--- a/ConvertUTF.c
+++ b/ConvertUTF.c
@@ -39,6 +39,7 @@
 ------------------------------------------------------------------------ */
 
 
+#include <stddef.h>
 #include "ConvertUTF.h"
 #ifdef CVTUTF_DEBUG
 #include <stdio.h>
@@ -364,14 +365,14 @@ ConversionResult ConvertUTF8toUTF16 (
 	ch -= offsetsFromUTF8[extraBytesToRead];
 
 	if (target >= targetEnd) {
-	    source -= (extraBytesToRead+1); /* Back up source pointer! */
+	    source -= ((ptrdiff_t)extraBytesToRead+1); /* Back up source pointer! */
 	    result = targetExhausted; break;
 	}
 	if (ch <= UNI_MAX_BMP) { /* Target is a character <= 0xFFFF */
 	    /* UTF-16 surrogate values are illegal in UTF-32 */
 	    if (ch >= UNI_SUR_HIGH_START && ch <= UNI_SUR_LOW_END) {
 		if (flags == strictConversion) {
-		    source -= (extraBytesToRead+1); /* return to the illegal value itself */
+		    source -= ((ptrdiff_t)extraBytesToRead+1); /* return to the illegal value itself */
 		    result = sourceIllegal;
 		    break;
 		} else {
@@ -383,7 +384,7 @@ ConversionResult ConvertUTF8toUTF16 (
 	} else if (ch > UNI_MAX_UTF16) {
 	    if (flags == strictConversion) {
 		result = sourceIllegal;
-		source -= (extraBytesToRead+1); /* return to the start */
+		source -= ((ptrdiff_t)extraBytesToRead+1); /* return to the start */
 		break; /* Bail out; shouldn't continue */
 	    } else {
 		*target++ = UNI_REPLACEMENT_CHAR;
@@ -391,7 +392,7 @@ ConversionResult ConvertUTF8toUTF16 (
 	} else {
 	    /* target is a character in range 0xFFFF - 0x10FFFF. */
 	    if (target + 1 >= targetEnd) {
-		source -= (extraBytesToRead+1); /* Back up source pointer! */
+		source -= ((ptrdiff_t)extraBytesToRead+1); /* Back up source pointer! */
 		result = targetExhausted; break;
 	    }
 	    ch -= halfBase;
@@ -490,7 +491,7 @@ ConversionResult ConvertUTF8toUTF32 (
 	ch -= offsetsFromUTF8[extraBytesToRead];
 
 	if (target >= targetEnd) {
-	    source -= (extraBytesToRead+1); /* Back up the source pointer! */
+	    source -= ((ptrdiff_t)extraBytesToRead+1); /* Back up the source pointer! */
 	    result = targetExhausted; break;
 	}
 	if (ch <= UNI_MAX_LEGAL_UTF32) {
@@ -500,7 +501,7 @@ ConversionResult ConvertUTF8toUTF32 (
 	     */
 	    if (ch >= UNI_SUR_HIGH_START && ch <= UNI_SUR_LOW_END) {
 		if (flags == strictConversion) {
-		    source -= (extraBytesToRead+1); /* return to the illegal value itself */
+		    source -= ((ptrdiff_t)extraBytesToRead+1); /* return to the illegal value itself */
 		    result = sourceIllegal;
 		    break;
 		} else {


### PR DESCRIPTION
extraBytesToRead is an unsigned short that is being subtracted from a pointer.  When adding 1 to extraBytesToRead, extraBytesToRead could potentially overflow before being subtracted from the pointer. Casting extraBytesToRead to ptrdiff_t ensures extraBytesToRead is the same size of a pointer, ensuring there is no loss of data before the subtraction occurs.