### PR TITLE
Add support to run tests building with cmake + ctest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,3 +35,7 @@ add_library(${EXPORT_NAMESPACE}${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 target_include_directories(${PROJECT_NAME} INTERFACE .)
 
+if(IS_TOPLEVEL_PROJECT)
+	enable_testing()
+	add_subdirectory(tests)
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,25 @@
+include(FetchContent)
+FetchContent_Declare(
+	googletest
+	URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.zip
+	URL_HASH SHA1=0ac421f2ec11af38b0fff0f1992184032731a8bc
+	DOWNLOAD_EXTRACT_TIMESTAMP ON)
+FetchContent_MakeAvailable(googletest)
+
+add_executable(tests
+	ts-bugfix.cpp
+	ts-noconvert.cpp
+	ts-quotes.cpp
+	ts-roundtrip.cpp
+	ts-snippets.cpp
+	ts-utf8.cpp)
+
+add_test(NAME tests COMMAND tests)
+target_link_libraries(tests PRIVATE ${PROJECT_NAME} gtest_main)
+
+add_custom_command(
+	TARGET tests POST_BUILD
+	COMMAND ${CMAKE_COMMAND} -E copy
+		${CMAKE_CURRENT_SOURCE_DIR}/example.ini
+		${CMAKE_CURRENT_SOURCE_DIR}/tests.ini
+		${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
This patch adds support to run tests even when we build the library with cmake from the toplevel (i.e. tests will not be build if we are using this library as a dependency in a subdir).