### PR TITLE
CMake: add cmake installation; add SIMPLEINI_USE_SYSTEM_GTEST option

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,13 +11,36 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Install requirements
-      run: sudo apt install libgtest-dev
+      run: sudo apt install libgtest-dev cmake
     - uses: actions/checkout@v3
     - run: make all && make test
+
+    - name: test with CMake (-DSIMPLEINI_USE_SYSTEM_GTEST=OFF)
+      run: |
+        cmake . -B build -DSIMPLEINI_USE_SYSTEM_GTEST=OFF
+        cmake --build build
+        ctest --test-dir build
+    - name: test with CMake (-DSIMPLEINI_USE_SYSTEM_GTEST=ON)
+      run: |
+        cmake . -B build-system-gtest -DSIMPLEINI_USE_SYSTEM_GTEST=ON
+        cmake --build build-system-gtest
+        ctest --test-dir build-system-gtest
+
   MacOS:
     runs-on: macos-latest
     steps:
     - name: Install requirements
-      run: brew install googletest
+      run: brew install googletest cmake
     - uses: actions/checkout@v3
     - run: make all && make test
+
+    - name: test with CMake (-DSIMPLEINI_USE_SYSTEM_GTEST=OFF)
+      run: |
+        cmake . -B build -DSIMPLEINI_USE_SYSTEM_GTEST=OFF
+        cmake --build build
+        ctest --test-dir build
+    - name: test with CMake (-DSIMPLEINI_USE_SYSTEM_GTEST=ON)
+      run: |
+        cmake . -B build-system-gtest -DSIMPLEINI_USE_SYSTEM_GTEST=ON
+        cmake --build build-system-gtest
+        ctest --test-dir build-system-gtest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,8 @@ else()
 	set(IS_TOPLEVEL_PROJECT FALSE)
 endif()
 
+option(SIMPLEINI_USE_SYSTEM_GTEST "Use system GoogleTest dependency" OFF)
+
 # Disable in-source builds:
 get_filename_component(srcdir "${CMAKE_SOURCE_DIR}" REALPATH)
 get_filename_component(bindir "${CMAKE_BINARY_DIR}" REALPATH)
@@ -33,7 +35,37 @@ set(HEADERS SimpleIni.h)
 add_library(${PROJECT_NAME} INTERFACE)
 add_library(${EXPORT_NAMESPACE}${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
-target_include_directories(${PROJECT_NAME} INTERFACE .)
+include(GNUInstallDirs)
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+	VERSION ${PROJECT_VERSION}
+	COMPATIBILITY SameMajorVersion
+)
+configure_package_config_file(${PROJECT_NAME}Config.cmake.in
+	${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+	INSTALL_DESTINATION ${CMAKE_INSTALL_DATADIR}/cmake/${PROJECT_NAME}
+)
+
+install(FILES SimpleIni.h
+	DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}
+)
+
+install(TARGETS ${PROJECT_NAME}
+	EXPORT ${PROJECT_NAME}Targets
+)
+
+install(FILES
+		${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+		${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+	DESTINATION ${CMAKE_INSTALL_DATADIR}/cmake/${PROJECT_NAME}
+)
+install(EXPORT ${PROJECT_NAME}Targets
+	DESTINATION ${CMAKE_INSTALL_DATADIR}/cmake/${PROJECT_NAME}
+	NAMESPACE EXPORT_NAMESPACE
+)
+
+target_include_directories(${PROJECT_NAME} INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 
 if(IS_TOPLEVEL_PROJECT)
 	enable_testing()

--- a/SimpleIniConfig.cmake.in
+++ b/SimpleIniConfig.cmake.in
@@ -1,0 +1,8 @@
+@PACKAGE_INIT@
+
+# prevent repeatedly including the targets
+if(NOT TARGET @PROJECT_NAME@::@PROJECT_NAME@)
+    include(${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake)
+endif()
+
+message(STATUS "Found @PROJECT_NAME@, version: ${@PROJECT_NAME@_VERSION}")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,10 +1,14 @@
-include(FetchContent)
-FetchContent_Declare(
-	googletest
-	URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.zip
-	URL_HASH SHA1=0ac421f2ec11af38b0fff0f1992184032731a8bc
-	DOWNLOAD_EXTRACT_TIMESTAMP ON)
-FetchContent_MakeAvailable(googletest)
+if(SIMPLEINI_USE_SYSTEM_GTEST)
+	find_package(GTest REQUIRED)
+else()
+	include(FetchContent)
+	FetchContent_Declare(
+		googletest
+		URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.zip
+		URL_HASH SHA1=0ac421f2ec11af38b0fff0f1992184032731a8bc
+		DOWNLOAD_EXTRACT_TIMESTAMP ON)
+	FetchContent_MakeAvailable(googletest)
+endif()
 
 add_executable(tests
 	ts-bugfix.cpp
@@ -15,7 +19,7 @@ add_executable(tests
 	ts-utf8.cpp)
 
 add_test(NAME tests COMMAND tests)
-target_link_libraries(tests PRIVATE ${PROJECT_NAME} gtest_main)
+target_link_libraries(tests PRIVATE ${PROJECT_NAME} GTest::gtest_main)
 
 add_custom_command(
 	TARGET tests POST_BUILD


### PR DESCRIPTION
The PR does the folllowing things, which will help for packaging in Linux when using CMake:

- Generate the CMake config, version and target files, and install them
- Installation of header file
- Add SIMPLEINI_USE_SYSTEM_GTEST option to choose to use system gtest dependency or not.