### PR TITLE
Define SI_NO_CONVERSION by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ set(HEADERS SimpleIni.h)
 
 add_library(${PROJECT_NAME} INTERFACE)
 add_library(${EXPORT_NAMESPACE}${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+target_compile_definitions(${PROJECT_NAME} INTERFACE SI_NO_CONVERSION)
 
 include(GNUInstallDirs)
 


### PR DESCRIPTION
Since `ConvertUTF.h` is not installed from CMake, `SI_NO_CONVERSION` should also be set, otherwise `SimpleIni.h` is not usable as it tries to include non-existing ` ConvertUTF.h`.