### PR TITLE
Update UTF-8 conversion functions and header definitions.

### DIFF
--- a/ConvertUTF.c
+++ b/ConvertUTF.c
@@ -194,7 +194,7 @@ static const UTF32 offsetsFromUTF8[6] = { 0x00000000UL, 0x00003080UL, 0x000E2080
  * Once the bits are split out into bytes of UTF-8, this is a mask OR-ed
  * into the first byte, depending on how many bytes follow.  There are
  * as many entries in this table as there are UTF-8 sequence types.
- * (I.e., one byte sequence, two byte... etc.). Remember that sequences
+ * (I.e., one byte sequence, two byte... etc.). Remember that sequencs
  * for *legal* UTF-8 will be 4 or fewer bytes total.
  */
 static const UTF8 firstByteMark[7] = { 0x00, 0x00, 0xC0, 0xE0, 0xF0, 0xF8, 0xFC };

--- a/ConvertUTF.c
+++ b/ConvertUTF.c
@@ -267,9 +267,13 @@ ConversionResult ConvertUTF16toUTF8 (
 	    target -= bytesToWrite; result = targetExhausted; break;
 	}
 	switch (bytesToWrite) { /* note: everything falls through. */
+	    /* FALLTHRU */
 	    case 4: *--target = (UTF8)((ch | byteMark) & byteMask); ch >>= 6;
+	    /* FALLTHRU */
 	    case 3: *--target = (UTF8)((ch | byteMark) & byteMask); ch >>= 6;
+	    /* FALLTHRU */
 	    case 2: *--target = (UTF8)((ch | byteMark) & byteMask); ch >>= 6;
+	    /* FALLTHRU */
 	    case 1: *--target =  (UTF8)(ch | firstByteMark[bytesToWrite]);
 	}
 	target += bytesToWrite;
@@ -298,8 +302,11 @@ static Boolean isLegalUTF8(const UTF8 *source, int length) {
     switch (length) {
     default: return false;
 	/* Everything else falls through when "true"... */
+	/* FALLTHRU */
     case 4: if ((a = (*--srcptr)) < 0x80 || a > 0xBF) return false;
+    /* FALLTHRU */
     case 3: if ((a = (*--srcptr)) < 0x80 || a > 0xBF) return false;
+    /* FALLTHRU */
     case 2: if ((a = (*--srcptr)) > 0xBF) return false;
 
 	switch (*source) {
@@ -311,6 +318,7 @@ static Boolean isLegalUTF8(const UTF8 *source, int length) {
 	    default:   if (a < 0x80) return false;
 	}
 
+    /* FALLTHRU */
     case 1: if (*source >= 0x80 && *source < 0xC2) return false;
     }
     if (*source > 0xF4) return false;
@@ -354,11 +362,17 @@ ConversionResult ConvertUTF8toUTF16 (
 	 * The cases all fall through. See "Note A" below.
 	 */
 	switch (extraBytesToRead) {
+		/* FALLTHRU */
 	    case 5: ch += *source++; ch <<= 6; /* remember, illegal UTF-8 */
+	    /* FALLTHRU */
 	    case 4: ch += *source++; ch <<= 6; /* remember, illegal UTF-8 */
+	    /* FALLTHRU */
 	    case 3: ch += *source++; ch <<= 6;
+	    /* FALLTHRU */
 	    case 2: ch += *source++; ch <<= 6;
+	    /* FALLTHRU */
 	    case 1: ch += *source++; ch <<= 6;
+	    /* FALLTHRU */
 	    case 0: ch += *source++;
 	}
 	ch -= offsetsFromUTF8[extraBytesToRead];
@@ -445,9 +459,13 @@ ConversionResult ConvertUTF32toUTF8 (
 	    target -= bytesToWrite; result = targetExhausted; break;
 	}
 	switch (bytesToWrite) { /* note: everything falls through. */
+	    /* FALLTHRU */
 	    case 4: *--target = (UTF8)((ch | byteMark) & byteMask); ch >>= 6;
+	    /* FALLTHRU */
 	    case 3: *--target = (UTF8)((ch | byteMark) & byteMask); ch >>= 6;
+	    /* FALLTHRU */
 	    case 2: *--target = (UTF8)((ch | byteMark) & byteMask); ch >>= 6;
+	    /* FALLTHRU */
 	    case 1: *--target = (UTF8) (ch | firstByteMark[bytesToWrite]);
 	}
 	target += bytesToWrite;
@@ -480,11 +498,17 @@ ConversionResult ConvertUTF8toUTF32 (
 	 * The cases all fall through. See "Note A" below.
 	 */
 	switch (extraBytesToRead) {
+		/* FALLTHRU */
 	    case 5: ch += *source++; ch <<= 6;
+	    /* FALLTHRU */
 	    case 4: ch += *source++; ch <<= 6;
+	    /* FALLTHRU */
 	    case 3: ch += *source++; ch <<= 6;
+	    /* FALLTHRU */
 	    case 2: ch += *source++; ch <<= 6;
+	    /* FALLTHRU */
 	    case 1: ch += *source++; ch <<= 6;
+	    /* FALLTHRU */
 	    case 0: ch += *source++;
 	}
 	ch -= offsetsFromUTF8[extraBytesToRead];

--- a/ConvertUTF.h
+++ b/ConvertUTF.h
@@ -24,7 +24,7 @@
 
     Conversions between UTF32, UTF-16, and UTF-8.  Header file.
 
-    Several functions are included here, forming a complete set of
+    Several funtions are included here, forming a complete set of
     conversions between the three formats.  UTF-7 is not included
     here, but is handled in a separate source file.
 
@@ -87,7 +87,7 @@
     bit mask & shift operations.
 ------------------------------------------------------------------------ */
 
-typedef unsigned int	UTF32;	/* at least 32 bits */
+typedef unsigned long	UTF32;	/* at least 32 bits */
 typedef unsigned short	UTF16;	/* at least 16 bits */
 typedef unsigned char	UTF8;	/* typically 8 bits */
 typedef unsigned char	Boolean; /* 0 or 1 */
@@ -102,7 +102,7 @@ typedef unsigned char	Boolean; /* 0 or 1 */
 typedef enum {
 	conversionOK, 		/* conversion successful */
 	sourceExhausted,	/* partial character in source, but hit end */
-	targetExhausted,	/* insufficient room in target for conversion */
+	targetExhausted,	/* insuff. room in target for conversion */
 	sourceIllegal		/* source sequence is illegal/malformed */
 } ConversionResult;
 

--- a/ConvertUTF_readme.txt
+++ b/ConvertUTF_readme.txt
@@ -1,0 +1,43 @@
+
+The accompanying C source code file "ConvertUTF.c" and the associated header
+file "ConvertUTF.h" provide for conversion between various transformation
+formats of Unicode characters.  The following conversions are supported:
+
+	UTF-32 to UTF-16
+	UTF-32 to UTF-8
+	UTF-16 to UTF-32
+	UTF-16 to UTF-8
+	UTF-8 to UTF-16
+	UTF-8 to UTF-32
+
+In addition, there is a test harness which runs various tests.
+
+The files "CVTUTF7.C" and "CVTUTF7.H" are for archival and historical purposes
+only. They have not been updated to Unicode 3.0 or later and should be
+considered obsolescent. "CVTUTF7.C" contains two functions that can convert
+between UCS2 (i.e., the BMP characters only) and UTF-7. Surrogates are
+not supported, the code has not been tested, and should be considered
+unsuitable for general purpose use.
+
+Please submit any bug reports about these programs here:
+
+	http://www.unicode.org/unicode/reporting.html
+
+Version 1.0: initial version.
+
+Version 1.1: corrected some minor problems; added stricter checks.
+
+Version 1.2: corrected switch statements associated with "extraBytesToRead"
+	in 4 & 5 byte cases, in functions for conversion from UTF8.
+	Note: formally, the 4 & 5 byte cases are illegal in the latest
+	UTF8, but the table and this code has always catered for those,
+	cases since at one time they were legal.
+
+Version 1.3: Updated UTF-8 legality check;
+	updated to use UNI_MAX_LEGAL_UTF32 in UTF-32 conversions
+	Updated UTF-8 legality tests in harness.c
+ 
+
+Last update: October 19, 2004
+https://web.archive.org/web/20081228105917/http://www.unicode.org/Public/PROGRAMS/CVTUTF/
+


### PR DESCRIPTION
- Corrected typos in comments
- Changed typedef for UTF32 to use unsigned long
- Updated enum member descriptions for clarity
