### PR TITLE
Simplify top level cmake file and use standard cmake testing variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,6 @@ project(
 )
 
 option(SIMPLEINI_USE_SYSTEM_GTEST "Use system GoogleTest dependency" OFF)
-option(SIMPLEINI_BUILD_TESTS "Build tests" ON)
-option(SIMPLEINI_BUILD_EXAMPLES "Build examples" ON)
 
 # disable in-source builds
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
@@ -17,28 +15,16 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
 endif()
 
 set(EXPORT_NAMESPACE "${PROJECT_NAME}::")
-set(SIMPLEINI_HEADERS SimpleIni.h)
 
-# ConvertUTF files are only needed on Windows for SI_CONVERT_WIN32
-if(WIN32)
-    list(APPEND SIMPLEINI_HEADERS ConvertUTF.h)
-    set(SIMPLEINI_SOURCES ConvertUTF.c)
-endif()
-
+# SimpleIni is a header-only library. The ConvertUTF.c/h files in this repository
+# are only required if users define SI_CONVERT_GENERIC. In that case, users must
+# manually copy and compile ConvertUTF.c into their own projects.
 add_library(${PROJECT_NAME} INTERFACE)
 add_library(${EXPORT_NAMESPACE}${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 target_include_directories(${PROJECT_NAME} INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
-
-# On Windows, add ConvertUTF.c as a source file
-if(WIN32)
-    target_sources(${PROJECT_NAME} INTERFACE
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/ConvertUTF.c>
-        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/ConvertUTF.c>
-    )
-endif()
 
 include(GNUInstallDirs)
 
@@ -49,19 +35,12 @@ write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Conf
 )
 configure_package_config_file(${PROJECT_NAME}Config.cmake.in
 	${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
-	INSTALL_DESTINATION ${CMAKE_INSTALL_DATADIR}/cmake/${PROJECT_NAME}
+	INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
 )
 
-install(FILES ${SIMPLEINI_HEADERS}
+install(FILES SimpleIni.h
 	DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
-
-# Install ConvertUTF.c on Windows (needed for SI_CONVERT_WIN32)
-if(WIN32)
-    install(FILES ConvertUTF.c
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-    )
-endif()
 
 install(TARGETS ${PROJECT_NAME}
     EXPORT SimpleIniTargets
@@ -69,8 +48,8 @@ install(TARGETS ${PROJECT_NAME}
 
 install(EXPORT SimpleIniTargets
     FILE SimpleIniTargets.cmake
-    NAMESPACE SimpleIni::
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/SimpleIni
+    NAMESPACE ${EXPORT_NAMESPACE}
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
 )
 
 install(FILES
@@ -79,8 +58,8 @@ install(FILES
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
 )
 
-# only build tests when top level and testing enabled
-if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND SIMPLEINI_BUILD_TESTS)
+# only build tests when top level
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
 	include(CTest)
 	if(BUILD_TESTING)
 		add_subdirectory(tests)


### PR DESCRIPTION
The standard cmake var BUILD_TESTING is the only var that needs to be set to disable testing. No need for us to be special. The convertUTF.* files aren't supposed to be installed. 